### PR TITLE
Fix for lamib-db schema deprecation - README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ uv pip install scprint[dev] # for the dev dependencies (building etc..) OR
 uv pip install scprint[flash] # to use flashattention2 with triton: only if you have a compatible gpu (e.g. not available for apple GPUs for now, see https://github.com/triton-lang/triton?tab=readme-ov-file#compatibility)
 #OR pip install scPRINT[dev,flash]
 
-lamin init --storage ./testdb --name test --schema bionty
+lamin init --storage ./testdb --name test --modules bionty
 ```
 
 if you start with lamin and had to do a `lamin init`, you will also need to populate your ontologies. This is because scPRINT is using ontologies to define its cell types, diseases, sexes, ethnicities, etc.


### PR DESCRIPTION
### Summary :memo:
_Write an overview about it._
lamin db does not support `--schema` anymore, instead use `--modules`

### Details
_Describe more what you did on changes._
1. Updated README.md
    ```
    lamin init \
      --storage ./testdb \
      --name test \
      --modules bionty
    ```

Error:
```
(scprint_venv) [nxi220005@utd scprint_testing]$ lamin init --storage ./testdb test --schema bionty

 Usage: lamin init [OPTIONS]

 Try 'lamin init --help' for help
╭─ Error ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Got unexpected extra argument (test)                                                                                                                                            │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

(scprint_venv) [nxi220005@utd scprint_testing]$ lamin init --help

 Usage: lamin init [OPTIONS]

 Init an instance.

╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --storage    TEXT  Local directory, s3://bucket_name, gs://bucket_name.                                                                                                         │
│ --db         TEXT  Postgres database connection URL, do not pass for SQLite.                                                                                                    │
│ --modules    TEXT  Comma-separated string of modules.                                                                                                                           │
│ --name       TEXT  The instance name.                                                                                                                                           │
│ --schema     TEXT  [DEPRECATED] Use --modules instead.                                                                                                                          │
│ --help             Show this message and exit.                                                                                                                                  │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

```
