### PR TITLE
fix: don't abort make_adata when ontology translation fails

### DIFF
--- a/scprint/model/utils.py
+++ b/scprint/model/utils.py
@@ -2,6 +2,7 @@ import gc
 import json
 import math
 import os.path
+import warnings
 from collections import Counter
 from typing import Dict, List, Optional, Union
 
@@ -124,11 +125,24 @@ def make_adata(
     accuracy = {}
     if pred is not None:
         for clss in classes:
+            # `translate` maps ontology ids to human-readable names for the
+            # convenience `conv_*` columns. It can raise on ids it cannot
+            # resolve (e.g. comma-joined CellxGene ethnicity terms); since
+            # these columns are cosmetic, warn and skip rather than aborting
+            # the whole prediction run. See cantinilab/scPRINT#49.
             if gtclass is not None:
-                tr = translate(adata.obs[clss].tolist(), clss)
+                try:
+                    tr = translate(adata.obs[clss].tolist(), clss)
+                except Exception as e:
+                    warnings.warn(f"could not translate ontology ids for '{clss}': {e}")
+                    tr = None
                 if tr is not None:
                     adata.obs["conv_" + clss] = adata.obs[clss].replace(tr)
-            tr = translate(adata.obs["pred_" + clss].tolist(), clss)
+            try:
+                tr = translate(adata.obs["pred_" + clss].tolist(), clss)
+            except Exception as e:
+                warnings.warn(f"could not translate ontology ids for 'pred_{clss}': {e}")
+                tr = None
             if tr is not None:
                 adata.obs["conv_pred_" + clss] = adata.obs["pred_" + clss].replace(tr)
             res = []


### PR DESCRIPTION
### Summary :memo:

`make_adata` calls `translate()` to populate the cosmetic `conv_*` columns with human-readable ontology names. `translate()` can raise on an id it cannot resolve — notably comma-joined CellxGene terms like `self_reported_ethnicity_ontology_term_id = "HANCESTRO:0005,HANCESTRO:0008"`, which a model legitimately predicts because such labels are in the training vocabulary. When that happens, the **entire prediction/embedding run aborts** (#49).

### Details

1. Wrap the two `translate()` calls in `make_adata` so a translation failure emits a `warnings.warn` and skips the affected `conv_*` column instead of raising.
2. The actual predictions (`pred_*` columns) and embeddings are untouched — only the optional human-readable convenience columns are affected.
3. The root cause is also fixed upstream in scdataloader's `translate()` (jkobject/scDataLoader#33, which resolves compound ids properly). This scPRINT-side change is defense-in-depth: it keeps `make_adata` robust regardless of the installed scdataloader version.

### Bugfixes :bug:
- `make_adata` no longer crashes the whole run when an ontology id (e.g. a compound CellxGene ethnicity term) can't be translated.

### Checks
- [x] Closes #49
- [x] Tested Changes — change is a localized try/except around an existing call; verified by inspection (no behaviour change on the success path, only the failure path now degrades gracefully)
- [ ] Stakeholder Approval