### PR TITLE
chore: bump scDataLoader floor to 2.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "torchdata>=0.7.1",
     "lamindb==2.1.1",
     "bionty>=1.0.0",
-    "scDataLoader>=2.1.2",
+    "scDataLoader>=2.1.3",
     "simpler_flash==1.0.7",
     "GRnnData>=1.1.5",
     "BenGRN>=1.3.0",


### PR DESCRIPTION
Picks up the freshly released scdataloader 2.1.3 (https://pypi.org/project/scdataloader/2.1.3/):
- scipy>=1.15 compat in `additional_postprocess` (jkobject/scDataLoader#32, #34)
- compound ontology id handling in `translate()` (jkobject/scDataLoader#33) — complements the in-tree #51 defense-in-depth in `make_adata`
- `lamin init --modules bionty` docs (lamindb 2.1.x)

No scPRINT-side code changes needed.